### PR TITLE
Feat/seminar rss ical

### DIFF
--- a/data/seminar.json
+++ b/data/seminar.json
@@ -1,0 +1,49 @@
+{
+  "items": [
+    {
+      "title": "Software Architects Are Dead—Long Live the AI-Augmented Architect!",
+      "from": "20260119T141500",
+      "to": "20260119T150000",
+      "location": "IMADA meeting room 4",
+      "map": "https://clients.mapsindoors.com/sdu/573f26e4bc1f571b08094312/details/aabc3bc3582f465fbd7614f3",
+      "videomeeting": "https://syddanskuni.zoom.us/j/62541149009",
+      "speaker": "Davide Taibi (SDU Veijle)",
+      "abstract": "What if the future of software architecture doesn’t need architects as we know them? As GenAI infiltrates every stage of the software development lifecycle, the traditional role of the architect—meticulously designing systems from requirements to deployment—is being unbundled, redefined, and partially outsourced to machines. And yet, the industry is far from ready.\nThis keynote presents a bold vision of the AI-Augmented Architect: a hybrid thinker who doesn’t write blueprints alone but designs with AI, using it not as a tool—but as a creative partner, a challenger, a simulator of trade-offs. Drawing from two cutting-edge empirical studies, including a multivocal review of GenAI in software architecture and a forward-looking survey of industry leaders, we’ll confront hard truths: AI is already doing architectural documentation, detecting antipatterns, and even suggesting design alternatives. But it’s also hallucinating, biasing decisions, and eroding accountability.\nIf we don’t rethink our roles, methods, and mindset, software architects risk becoming passive validators of AI output rather than strategic designers of complex systems. The good news? There is still time to adapt—but only if we embrace a future where architecture is not less human, but more profoundly human because of our collaboration with machines."
+    },
+    {
+      "title": "New quality-of-life features for the Choral compiler",
+      "from": "20260209T150000",
+      "to": "20260209T154500",
+      "location": "IMADA meeting room 4",
+      "map": "https://clients.mapsindoors.com/sdu/573f26e4bc1f571b08094312/details/aabc3bc3582f465fbd7614f3",
+      "videomeeting": "https://syddanskuni.zoom.us/j/62541149009",
+      "speaker": "Malthe Petersen (Dan Plyukhin's M.Sc. student)"
+    },
+    {
+      "title": "Synthesizing Feature Models from Rust Configurations with an FCA-based analysis",
+      "from": "20260216T131500",
+      "to": "20260216T140000",
+      "location": "IMADA meeting room 3",
+      "map": "https://clients.mapsindoors.com/sdu/573f26e4bc1f571b08094312/details/563cba2e423b7d0540c9ad58",
+      "videomeeting": "https://syddanskuni.zoom.us/j/62541149009",
+      "speaker": "Bjarke Paluszewski (Sandra Greiner's M.Sc. student)",
+      "abstract": "Rust is a modern language that guarantees memory-safety while supporting low-level concepts similar to C and C++. Particularly, it has a built-in feature-expression language and allows for configuring the usage of Rust crates (libraries) used in other Rust projects. Yet the variability in the Rust ecosystem remains largely undiscovered leaving developers confronted with several issues such as including too many unnecessary features, feature versioning, and possible feature interactions. In our talk, we demonstrate how to analyze the variability inherent in single Rust crates. We show how a feature model can be synthesized by different Rust configurations (selection of features of a used Rust library in another Rust project) using an FCA based method. We analyze the resulting feature models to understand the size of the configuration space and the usage of features among Rust libraries."
+    },
+    {
+      "from": "20260223T141500",
+      "to": "20260223T150000",
+      "location": "IMADA meeting room 4",
+      "map": "https://clients.mapsindoors.com/sdu/573f26e4bc1f571b08094312/details/aabc3bc3582f465fbd7614f3",
+      "videomeeting": "https://syddanskuni.zoom.us/j/62541149009",
+      "speaker": "Robin Kaarsgaard Sales"
+    },
+    {
+      "from": "20260302T141500",
+      "to": "20260302T150000",
+      "location": "IMADA meeting room 4",
+      "map": "https://clients.mapsindoors.com/sdu/573f26e4bc1f571b08094312/details/aabc3bc3582f465fbd7614f3",
+      "videomeeting": "https://syddanskuni.zoom.us/j/62541149009",
+      "speaker": "Dan Plyukhin"
+    }
+  ]
+}

--- a/data/seminar.json
+++ b/data/seminar.json
@@ -8,7 +8,8 @@
       "map": "https://clients.mapsindoors.com/sdu/573f26e4bc1f571b08094312/details/aabc3bc3582f465fbd7614f3",
       "videomeeting": "https://syddanskuni.zoom.us/j/62541149009",
       "speaker": "Davide Taibi (SDU Veijle)",
-      "abstract": "What if the future of software architecture doesn’t need architects as we know them? As GenAI infiltrates every stage of the software development lifecycle, the traditional role of the architect—meticulously designing systems from requirements to deployment—is being unbundled, redefined, and partially outsourced to machines. And yet, the industry is far from ready.\nThis keynote presents a bold vision of the AI-Augmented Architect: a hybrid thinker who doesn’t write blueprints alone but designs with AI, using it not as a tool—but as a creative partner, a challenger, a simulator of trade-offs. Drawing from two cutting-edge empirical studies, including a multivocal review of GenAI in software architecture and a forward-looking survey of industry leaders, we’ll confront hard truths: AI is already doing architectural documentation, detecting antipatterns, and even suggesting design alternatives. But it’s also hallucinating, biasing decisions, and eroding accountability.\nIf we don’t rethink our roles, methods, and mindset, software architects risk becoming passive validators of AI output rather than strategic designers of complex systems. The good news? There is still time to adapt—but only if we embrace a future where architecture is not less human, but more profoundly human because of our collaboration with machines."
+      "abstract": "What if the future of software architecture doesn’t need architects as we know them? As GenAI infiltrates every stage of the software development lifecycle, the traditional role of the architect—meticulously designing systems from requirements to deployment—is being unbundled, redefined, and partially outsourced to machines. And yet, the industry is far from ready.\nThis keynote presents a bold vision of the AI-Augmented Architect: a hybrid thinker who doesn’t write blueprints alone but designs with AI, using it not as a tool—but as a creative partner, a challenger, a simulator of trade-offs. Drawing from two cutting-edge empirical studies, including a multivocal review of GenAI in software architecture and a forward-looking survey of industry leaders, we’ll confront hard truths: AI is already doing architectural documentation, detecting antipatterns, and even suggesting design alternatives. But it’s also hallucinating, biasing decisions, and eroding accountability.\nIf we don’t rethink our roles, methods, and mindset, software architects risk becoming passive validators of AI output rather than strategic designers of complex systems. The good news? There is still time to adapt—but only if we embrace a future where architecture is not less human, but more profoundly human because of our collaboration with machines.",
+      "pubDate": "Sun, 26 Oct 2025 00:00:00 +0000"
     },
     {
       "title": "New quality-of-life features for the Choral compiler",
@@ -17,7 +18,8 @@
       "location": "IMADA meeting room 4",
       "map": "https://clients.mapsindoors.com/sdu/573f26e4bc1f571b08094312/details/aabc3bc3582f465fbd7614f3",
       "videomeeting": "https://syddanskuni.zoom.us/j/62541149009",
-      "speaker": "Malthe Petersen (Dan Plyukhin's M.Sc. student)"
+      "speaker": "Malthe Petersen (Dan Plyukhin's M.Sc. student)",
+      "pubDate": "Mon, 27 Oct 2025 00:00:00 +0000"
     },
     {
       "title": "Synthesizing Feature Models from Rust Configurations with an FCA-based analysis",
@@ -27,7 +29,8 @@
       "map": "https://clients.mapsindoors.com/sdu/573f26e4bc1f571b08094312/details/563cba2e423b7d0540c9ad58",
       "videomeeting": "https://syddanskuni.zoom.us/j/62541149009",
       "speaker": "Bjarke Paluszewski (Sandra Greiner's M.Sc. student)",
-      "abstract": "Rust is a modern language that guarantees memory-safety while supporting low-level concepts similar to C and C++. Particularly, it has a built-in feature-expression language and allows for configuring the usage of Rust crates (libraries) used in other Rust projects. Yet the variability in the Rust ecosystem remains largely undiscovered leaving developers confronted with several issues such as including too many unnecessary features, feature versioning, and possible feature interactions. In our talk, we demonstrate how to analyze the variability inherent in single Rust crates. We show how a feature model can be synthesized by different Rust configurations (selection of features of a used Rust library in another Rust project) using an FCA based method. We analyze the resulting feature models to understand the size of the configuration space and the usage of features among Rust libraries."
+      "abstract": "Rust is a modern language that guarantees memory-safety while supporting low-level concepts similar to C and C++. Particularly, it has a built-in feature-expression language and allows for configuring the usage of Rust crates (libraries) used in other Rust projects. Yet the variability in the Rust ecosystem remains largely undiscovered leaving developers confronted with several issues such as including too many unnecessary features, feature versioning, and possible feature interactions. In our talk, we demonstrate how to analyze the variability inherent in single Rust crates. We show how a feature model can be synthesized by different Rust configurations (selection of features of a used Rust library in another Rust project) using an FCA based method. We analyze the resulting feature models to understand the size of the configuration space and the usage of features among Rust libraries.",
+      "pubDate": "Tue, 28 Oct 2025 00:00:00 +0000"
     },
     {
       "from": "20260223T141500",
@@ -35,7 +38,8 @@
       "location": "IMADA meeting room 4",
       "map": "https://clients.mapsindoors.com/sdu/573f26e4bc1f571b08094312/details/aabc3bc3582f465fbd7614f3",
       "videomeeting": "https://syddanskuni.zoom.us/j/62541149009",
-      "speaker": "Robin Kaarsgaard Sales"
+      "speaker": "Robin Kaarsgaard Sales",
+      "pubDate": "Wed, 29 Oct 2025 00:00:00 +0000"
     },
     {
       "from": "20260302T141500",
@@ -43,7 +47,8 @@
       "location": "IMADA meeting room 4",
       "map": "https://clients.mapsindoors.com/sdu/573f26e4bc1f571b08094312/details/aabc3bc3582f465fbd7614f3",
       "videomeeting": "https://syddanskuni.zoom.us/j/62541149009",
-      "speaker": "Dan Plyukhin"
+      "speaker": "Dan Plyukhin",
+      "pubDate": "Thu, 30 Oct 2025 00:00:00 +0000"
     }
   ]
 }

--- a/main.ol
+++ b/main.ol
@@ -5,7 +5,7 @@ from mustache import Mustache
 from reflection import Reflection
 from runtime import Runtime
 from file import File
-from time import Time
+from values import Values
 from @jolie.leonardo import WebFiles
 from @jolie.commonmark import CommonMark
 
@@ -47,12 +47,14 @@ type SeminarTalk {
   title?: string
   from: string
   to: string
-  humanReadableDatetime?: string
   location: string
   map?: string
   videomeeting?: string
   speaker: string
   abstract?: string
+  pubDate: string
+  humanReadableDatetime: string
+  guid: int
 }
 
 /// Scheduled ACP seminar talks
@@ -76,10 +78,6 @@ RequestResponse:
 
 	/// Gets the data needed by the seminar pages
 	seminar( void )( SeminarData ),
-
-	/// Gets the data needed by the seminar pages, but with the datetimes in a
-  /// human readable format
-	seminarHumanReadable( void )( SeminarData )
 }
 
 service Main {
@@ -92,7 +90,7 @@ service Main {
 	embed Runtime as runtime
 	embed Reflection as reflection
 	embed File as file
-  embed Time as time
+  embed Values as values
 	embed CommonMark as commonMark
 
 	inputPort WebInput {
@@ -134,7 +132,8 @@ service Main {
 		global.dataBindings.("/index.html") = "index"
 		global.dataBindings.("/research/index.html") = "researchIndex"
 		global.dataBindings.("/news.html") = "news"
-		global.dataBindings.("/seminar.html") = "seminarHumanReadable"
+		global.dataBindings.("/seminar/index.html") = "seminar"
+		global.dataBindings.("/seminar/index.xml") = "seminar"
 	}
 
 	main {
@@ -212,21 +211,18 @@ service Main {
 
 		[ seminar()( response ) {
 			readFile@file( { filename = "data/seminar.json", format = "json" } )( response.seminar )
-		} ]
-
-		[ seminarHumanReadable()( response ) {
-			seminar@self()( response )
-			for( item in response.seminar.items ) {
-        // getDateTimeValues@time does not seem to work?
-        fmt@stringUtils( "{y}/{m}/{d}, {hf}:{mf}-{ht}:{mt}" {
-          y = substring@stringUtils( item.from { begin = 0, end = 4 } ),
-          m = substring@stringUtils( item.from { begin = 4, end = 6 } ),
-          d = substring@stringUtils( item.from { begin = 6, end = 8 } ),
-          hf = substring@stringUtils( item.from { begin = 9, end = 11 } ),
-          mf = substring@stringUtils( item.from { begin = 11, end = 13 } ),
-          ht = substring@stringUtils( item.to { begin = 9, end = 11 } ),
-          mt = substring@stringUtils( item.to { begin = 11, end = 13 } ),
-          } )( item.humanReadableDatetime )
+			for ( i in response.seminar.items) {
+        i.guid = hashCode@values( i )
+        // getDateTimeValues does not seem to work?
+        i.humanReadableDatetime = fmt@stringUtils( "{y}/{m}/{d}, {hf}:{mf}-{ht}:{mt}" {
+        y = substring@stringUtils( i.from { begin = 0, end = 4 } ),
+        m = substring@stringUtils( i.from { begin = 4, end = 6 } ),
+        d = substring@stringUtils( i.from { begin = 6, end = 8 } ),
+        hf = substring@stringUtils( i.from { begin = 9, end = 11 } ),
+        mf = substring@stringUtils( i.from { begin = 11, end = 13 } ),
+        ht = substring@stringUtils( i.to { begin = 9, end = 11 } ),
+        mt = substring@stringUtils( i.to { begin = 11, end = 13 } ),
+        } )
       }
 		} ]
 	}

--- a/main.ol
+++ b/main.ol
@@ -134,6 +134,7 @@ service Main {
 		global.dataBindings.("/news.html") = "news"
 		global.dataBindings.("/seminar/index.html") = "seminar"
 		global.dataBindings.("/seminar/index.xml") = "seminar"
+		global.dataBindings.("/seminar/index.ics") = "seminar"
 	}
 
 	main {

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -8,7 +8,7 @@
 	<ul id="navBox" class="hidden inline-flex md:inline-flex m-auto nav-list flex-wrap gap-3 place-content-center">
 		<li><a href="/#news"><button type="button">News</button></a></li>
 		<li><a href="/#people"><button type="button">People</button></a></li>
-		<li><a href="/seminar.html"><button type="button">Seminar</button></a></li>
+		<li><a href="/seminar/"><button type="button">Seminar</button></a></li>
 		<!-- <li><a href="#research"><button type="button">Research</button></a></li> -->
 		<li><a href="/research/"><button type="button">Research & Projects</button></a></li>
 		<li><a href="/education/"><button type="button">Education</button></a></li>

--- a/web/index.html
+++ b/web/index.html
@@ -56,7 +56,7 @@
 <script type="module" src="https://esm.sh/emfed@1"></script>
  
 <p class="mt-4 text-right"><a href="/news.html">See all news</a> |
-      <a href="https://mastodon.acm.org/@acp.rss">RSS</a></p>
+      <a href="https://mastodon.acm.org/@acp.rss"><i class="fa-solid fa-rss"></i></a></p>
 </section>
 
 <section id="people" class="section-container">

--- a/web/news.html
+++ b/web/news.html
@@ -4,7 +4,7 @@
 <p>Recent news on this webpage are queried from the
 <a href="https://mastodon.acm.org/@acp" rel="alternate external"
     target="_blank">ACP Fediverse account</a> (an <a
-    href="https://mastodon.acm.org/@acp.rss">RSS feed</a> is also available). News prior
+    href="https://mastodon.acm.org/@acp.rss">RSS feed <i class="fa-solid fa-rss"></i></a> is also available). News prior
   to September 2025 are queried from this website's local archive.</p>
 <!-- https://docs.joinmastodon.org/methods/accounts/#query-parameters-1 -->
 <a class="mastodon-feed"

--- a/web/seminar.html
+++ b/web/seminar.html
@@ -2,12 +2,16 @@
 {{$title}}Seminar{{/title}}
 {{$content}}
 <ul>
-	<li class="mb-2"><b class="mr-2">January 19</b>Davide Taibi (SDU Vejle)</li>
-	<li class="mb-2"><b class="mr-2">February 2</b>CANCELLED</li>
-	<li class="mb-2"><b class="mr-2">February 9</b>Malthe's MSc project update</li>
-	<li class="mb-2"><b class="mr-2">February 16</b>(at 13:15) Bjarke's MSc project update</li>
-	<li class="mb-2"><b class="mr-2">February 23</b>Robin Kaarsgaard Sales</li>
-	<li class="mb-2"><b class="mr-2">March 2</b>Dan Plyukhin</li>
+  {{#seminar}}
+  {{#items}}
+  <h2>{{humanReadableDatetime}} {{#title}}— {{.}}{{/title}}</h2>
+  <p><i>{{speaker}}
+    | {{#map}}<a href="{{.}}">{{/map}}{{location}}{{#map}}</a>{{/map}}
+    {{#videomeeting}} | <a href="{{.}}">video meeting</a>{{/videomeeting}}
+  </i></p>
+  <p>{{abstract}}</p>
+  {{/items}}
+  {{/seminar}}
 </ul>
 {{/content}}
 {{/page-container.html}}

--- a/web/seminar/index.html
+++ b/web/seminar/index.html
@@ -1,6 +1,10 @@
 {{< page-container.html}}
 {{$title}}Seminar{{/title}}
 {{$content}}
+<p class="mt-4 text-right">
+	<a href="./index.xml" title="RSS"><i class="fa-solid fa-rss"></i></a>
+	<a href="./index.ics" title="ICAL"><i class="fa-solid fa-calendar"></i></a>
+  </p>
 <ul>
   {{#seminar}}
   {{#items}}
@@ -9,7 +13,12 @@
     | {{#map}}<a href="{{.}}">{{/map}}{{location}}{{#map}}</a>{{/map}}
     {{#videomeeting}} | <a href="{{.}}">video meeting</a>{{/videomeeting}}
   </i></p>
-  <p>{{abstract}}</p>
+  {{#abstract}}
+  <details>
+    <summary>Abstract</summary>
+    <p>{{.}}</p>
+  </details>
+  {{/abstract}}
   {{/items}}
   {{/seminar}}
 </ul>

--- a/web/seminar/index.html
+++ b/web/seminar/index.html
@@ -3,7 +3,7 @@
 {{$content}}
 <p class="mt-4 text-right">
 	<a href="./index.xml" title="RSS"><i class="fa-solid fa-rss"></i></a>
-	<a href="./index.ics" title="ICAL"><i class="fa-solid fa-calendar"></i></a>
+	<a href="webcal://acp.sdu.dk/seminar/index.ics" title="ICAL"><i class="fa-solid fa-calendar"></i></a>
   </p>
 <ul>
   {{#seminar}}

--- a/web/seminar/index.ics
+++ b/web/seminar/index.ics
@@ -1,0 +1,26 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-https://acp.sdu.dk/seminar.html
+CALSCALE:GREGORIAN
+X-WR-CALNAME:ACP
+X-WR-CALDESC:ACP Seminar
+X-WR-TIMEZONE:Europe/Copenhagen
+METHOD:PUBLISH
+{{#seminar}}
+{{#items}}
+BEGIN:VEVENT
+CLASS:PUBLIC
+DESCRIPTION:Speaker: {{speaker}}\nTime: {{humanReadableDatetime}}\n{{#map}}Directions: {{.}}\n{{/map}}{{#videomeeting}}Video meeting: {{.}}\n{{/videomeeting}}\n{{abstract}}
+DTSTART:{{from}}
+DTEND:{{to}}
+LOCATION:{{location}}
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:ACP Seminar Talk{{#title}}: "{{.}}"{{/title}}
+TRANSP:OPAQUE
+URL:https://acp.sdu.dk/seminar.html
+UID:{{guid}}
+END:VEVENT
+{{/items}}
+{{/seminar}}
+END:VCALENDAR

--- a/web/seminar/index.xml
+++ b/web/seminar/index.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>ACP Seminar</title>
+    <link>https://plsl.acp.sdu.dk/seminar</link>
+    <description>Talks of the ACP Seminar</description>
+    <generator>Leonardo: the Jolie Web Server</generator>
+    <language>en-GB</language>
+    <copyright>© ACP</copyright>
+    <atom:link href="https://acp.sdu.dk/seminar/index.xml" rel="self" type="application/rss+xml" />
+  {{#seminar}}
+  {{#items}}
+    <item>
+      <title>ACP Seminar Talk{{#title}}: "{{.}}"{{/title}}</title>
+      <link>https://plsl.acp.sdu.dk/seminar</link>
+      <pubDate>{{pubDate}}</pubDate>
+      <author>{{speaker}}</author>
+      <guid isPermaLink="false">{{guid}}</guid>
+      <description><![CDATA[
+        Time: {{humanReadableDatetime}}<br/>
+        Location: {{#map}}<a href="{{.}}">{{/map}}{{location}}{{#map}}</a>{{/map}}<br/>
+        Video meeting: {{#videomeeting}}<a href="{{.}}">click here</a>{{/videomeeting}}<br/>
+        <p>{{abstract}}</p>]]></description>
+    </item>
+  {{/items}}
+  {{/seminar}}
+  </channel>
+</rss>

--- a/web/seminar/index.xml
+++ b/web/seminar/index.xml
@@ -2,7 +2,7 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>ACP Seminar</title>
-    <link>https://plsl.acp.sdu.dk/seminar</link>
+    <link>https://acp.sdu.dk/seminar</link>
     <description>Talks of the ACP Seminar</description>
     <generator>Leonardo: the Jolie Web Server</generator>
     <language>en-GB</language>
@@ -12,14 +12,13 @@
   {{#items}}
     <item>
       <title>ACP Seminar Talk{{#title}}: "{{.}}"{{/title}}</title>
-      <link>https://plsl.acp.sdu.dk/seminar</link>
-      <pubDate>{{pubDate}}</pubDate>
+      <link>https://acp.sdu.dk/seminar</link>
       <author>{{speaker}}</author>
       <guid isPermaLink="false">{{guid}}</guid>
       <description><![CDATA[
         Time: {{humanReadableDatetime}}<br/>
         Location: {{#map}}<a href="{{.}}">{{/map}}{{location}}{{#map}}</a>{{/map}}<br/>
-        Video meeting: {{#videomeeting}}<a href="{{.}}">click here</a>{{/videomeeting}}<br/>
+        {{#videomeeting}}Video meeting: <a href="{{.}}">click here</a><br/>{{/videomeeting}}
         <p>{{abstract}}</p>]]></description>
     </item>
   {{/items}}


### PR DESCRIPTION
## Back-end

Seminar talks are now:

- managed as a JSON file, rather than hard-coded in HTML;
- available as an RSS feed, as well as an ICAL calendar. People don't have to monitor MicroSlop Teams anymore!